### PR TITLE
SUS-7308 added some error support for interop with Objc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+## Subprocess
+
+Subprocess is a Swift library for macOS providing interfaces for both synchronous and asynchronous process execution. 
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Breaking: added the output of the command to Shell's exception exitedWithNonZeroStatus error to better conform to objc interop and NSError
+
+
+## 1.1.0 - 2020-05-15
+
+### Added
+- Added dynamic library targets to SPM
+
+### Fixed
+- Fixed naming convention to match Jamf internal convention
+
+## 1.0.1 - 2020-03-13
+
+### Added
+- Added Cocoapods support
+
+
+## 1.0.0 - 2020-03-13
+
+### Added
+- All support for the initial release 

--- a/Sources/Subprocess/Errors.swift
+++ b/Sources/Subprocess/Errors.swift
@@ -64,7 +64,7 @@ extension SubprocessError: LocalizedError {
     }
 }
 
-/// Gets us the NSError methods for when used by Objective-C
+/// Common NSError methods for better interop with Objective-C
 extension SubprocessError: CustomNSError {
     public var errorCode: Int {
         switch self {

--- a/Sources/Subprocess/Errors.swift
+++ b/Sources/Subprocess/Errors.swift
@@ -52,9 +52,11 @@ extension SubprocessError: LocalizedError {
         switch self {
         case .exitedWithNonZeroStatus(_, let errorMessage):
             return "\(errorMessage)"
-        case .unexpectedPropertyListObject:
+        case .unexpectedPropertyListObject(_):
+            // Ignoring the plist contents parameter as we don't want that in the error message
             return "The property list object could not be cast to expected type"
-        case .unexpectedJSONObject:
+        case .unexpectedJSONObject(_):
+            // Ignoring the json contents parameter as we don't want that in the error message
             return "The JSON object could not be cast to expected type"
         case .inputStringEncodingError:
             return "Input string could not be encoded"

--- a/Sources/Subprocess/Errors.swift
+++ b/Sources/Subprocess/Errors.swift
@@ -31,7 +31,8 @@ import Foundation
 public enum SubprocessError: Error {
 
     /// The process completed with a non-zero exit code
-    case exitedWithNonZeroStatus(Int32)
+    /// and a custom error message.
+    case exitedWithNonZeroStatus(Int32, String)
 
     /// The property list object could not be cast to expected type
     case unexpectedPropertyListObject(String)
@@ -44,4 +45,35 @@ public enum SubprocessError: Error {
 
     /// Output string could not be encoded
     case outputStringEncodingError
+}
+
+extension SubprocessError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .exitedWithNonZeroStatus(_, let errorMessage):
+            return "\(errorMessage)"
+        case .unexpectedPropertyListObject:
+            return "The property list object could not be cast to expected type"
+        case .unexpectedJSONObject:
+            return "The JSON object could not be cast to expected type"
+        case .inputStringEncodingError:
+            return "Input string could not be encoded"
+        case .outputStringEncodingError:
+            return "Output string could not be encoded"
+        }
+    }
+}
+
+/// Gets us the NSError methods for when used by Objective-C
+extension SubprocessError: CustomNSError {
+    public var errorCode: Int {
+        switch self {
+        case .exitedWithNonZeroStatus(let errorCode, _):
+            return Int(errorCode)
+        case .unexpectedPropertyListObject: return 10
+        case .unexpectedJSONObject: return 20
+        case .inputStringEncodingError: return 30
+        case .outputStringEncodingError: return 40
+        }
+    }
 }

--- a/Sources/Subprocess/Info.plist
+++ b/Sources/Subprocess/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/SubprocessMocks/Info.plist
+++ b/Sources/SubprocessMocks/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Subprocess.podspec
+++ b/Subprocess.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Subprocess'
-  s.version      = '1.0.1'
+  s.version      = '2.0.0'
   s.summary      = 'Wrapper for NSTask used for running processes and shell commands on macOS.'
   s.license      = { :type => 'MIT', :text => "" }
   s.description  = <<-DESC

--- a/Subprocess.xcodeproj/project.pbxproj
+++ b/Subprocess.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		6EDDC6DA241037F500E171C6 /* MockSubprocessDependencyBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6AF2410378100E171C6 /* MockSubprocessDependencyBuilder.swift */; };
 		6EDDC6DB241037F500E171C6 /* MockProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6B12410378100E171C6 /* MockProcess.swift */; };
 		6EDDC6E52410391500E171C6 /* Subprocess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EDDC6382410369400E171C6 /* Subprocess.framework */; };
-		6EDDC6F92410395800E171C6 /* ShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6B82410378100E171C6 /* ShellTests.swift */; };
+		6EDDC6F92410395800E171C6 /* ShellSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6B82410378100E171C6 /* ShellSystemTests.swift */; };
 		6EDDC6FB2410396000E171C6 /* SubprocessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6BC2410378100E171C6 /* SubprocessTests.swift */; };
 		6EDDC6FC2410396000E171C6 /* ShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6BD2410378100E171C6 /* ShellTests.swift */; };
 		6EDDC6FD24105F8300E171C6 /* SubprocessMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EDDC6CB241037CE00E171C6 /* SubprocessMocks.framework */; };
@@ -61,7 +61,7 @@
 		6EDDC6B02410378100E171C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6EDDC6B12410378100E171C6 /* MockProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProcess.swift; sourceTree = "<group>"; };
 		6EDDC6B22410378100E171C6 /* Subprocess.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Subprocess.podspec; sourceTree = "<group>"; };
-		6EDDC6B82410378100E171C6 /* ShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellTests.swift; sourceTree = "<group>"; };
+		6EDDC6B82410378100E171C6 /* ShellSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellSystemTests.swift; sourceTree = "<group>"; };
 		6EDDC6B92410378100E171C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6EDDC6BC2410378100E171C6 /* SubprocessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubprocessTests.swift; sourceTree = "<group>"; };
 		6EDDC6BD2410378100E171C6 /* ShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellTests.swift; sourceTree = "<group>"; };
@@ -182,7 +182,7 @@
 		6EDDC6B52410378100E171C6 /* SystemTests */ = {
 			isa = PBXGroup;
 			children = (
-				6EDDC6B82410378100E171C6 /* ShellTests.swift */,
+				6EDDC6B82410378100E171C6 /* ShellSystemTests.swift */,
 				6EDDC6B92410378100E171C6 /* Info.plist */,
 			);
 			path = SystemTests;
@@ -452,7 +452,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6EDDC6F92410395800E171C6 /* ShellTests.swift in Sources */,
+				6EDDC6F92410395800E171C6 /* ShellSystemTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SystemTests/ShellSystemTests.swift
+++ b/Tests/SystemTests/ShellSystemTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Subprocess
 
-final class ShellTests: XCTestCase {
+final class ShellSystemTests: XCTestCase {
 
     override func setUp() {
         SubprocessDependencyBuilder.shared = SubprocessDependencyBuilder()


### PR DESCRIPTION
- Added localized description support for SubprocessError
- Added NSError support for SubprocessError (just exit code for now)
- Changed the "combined" output to always have stdout before stderr
