### PR TITLE
Provide public environment access to underlying process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+.DS_Store

--- a/Sources/Subprocess/Subprocess.swift
+++ b/Sources/Subprocess/Subprocess.swift
@@ -45,6 +45,16 @@ open class Subprocess {
     /// Reason for process termination
     public var terminationReason: Process.TerminationReason { reference.terminationReason }
 
+    /// Reference environment property
+    public var environment: [String: String]? {
+        get {
+            reference.environment
+        }
+        set {
+            reference.environment = newValue
+        }
+    }
+
     /// Creates new Subprocess
     ///
     /// - Parameter command: Command represented as an array of strings

--- a/Sources/SubprocessMocks/MockProcess.swift
+++ b/Sources/SubprocessMocks/MockProcess.swift
@@ -136,6 +136,17 @@ open class MockProcessReference: Process {
     /// standardError object as a Pipe
     public var standardErrorPipe: Pipe? { standardError as? Pipe }
 
+    /// Environment property
+    private var _environment: [String: String]?
+    open override var environment: [String: String]? {
+        get {
+            return _environment
+        }
+        set {
+            _environment = newValue
+        }
+    }
+
     /// Completes the mock process execution
     /// - Parameters:
     ///     - statusCode: Exit code of the process (Default: 0)

--- a/Tests/UnitTests/SubprocessTests.swift
+++ b/Tests/UnitTests/SubprocessTests.swift
@@ -226,4 +226,18 @@ final class SubprocessTests: XCTestCase {
         waitForExpectations(timeout: 5.0)
         Subprocess.verify { XCTFail($0.message, file: $0.file, line: $0.line) }
     }
+
+    func testEnvironmentProperty() {
+        // Given
+        let subprocess = Subprocess(["/bin/echo"])
+        let environmentVariableName = "FOO"
+        let environmentVariableValue = "BAR"
+
+        // When
+        subprocess.environment = [environmentVariableName: environmentVariableValue]
+
+        // Then
+        XCTAssertEqual(subprocess.environment?[environmentVariableName], environmentVariableValue,
+                       "The environment property did not store the value correctly.")
+    }
 }


### PR DESCRIPTION
For my current project, I needed a way to provide an environment var to the command I was running in `Subprocess`. Because the binary I'm executing is in my app bundle, certain env vars weren't available and my code wasn't working properly. This update provides public access to the reference implementation's `Process` `environment` property. My PR here includes a test to exercise the feature. Please let me know if I'm overlooking anything in applying this PR.