### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Language](http://img.shields.io/badge/language-Swift-success.svg?style=flat)](https://developer.apple.com/swift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-success.svg?style=flat)](https://swift.org/package-manager)
-[![Documentation](docs/badge.svg)](./docs/index.html)
+[![Documentation](docs/badge.svg)](https://engineering.jamf.com/Subprocess/documentation/subprocess/)
 
 Subprocess is a Swift library for macOS providing interfaces for both synchronous and asynchronous process execution. 
 SubprocessMocks can be used in unit tests for quick and highly customizable mocking and verification of Subprocess usage. 


### PR DESCRIPTION
Unfortunately the link in our README for our docs did not get updated with #14. This is a quick fix to address that