### PR TITLE
Add modern Swift Concurrency support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,10 @@ on:
 jobs:
   spm:
     name: SwiftPM build and test
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
+    - run: |
+        sudo xcode-select -s /Applications/Xcode_15.0.app
     - uses: actions/checkout@v3
     - name: Build swift packages
       run: swift build -v
@@ -22,8 +24,10 @@ jobs:
       run: swift test -v
   carthage:
     name: Xcode project build and test
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
+    - run: |
+        sudo xcode-select -s /Applications/Xcode_15.0.app
     - uses: actions/checkout@v3
     - name: Build xcode project
       run: xcodebuild build -scheme 'SubprocessMocks' -derivedDataPath .build
@@ -31,8 +35,10 @@ jobs:
       run: xcodebuild test -scheme 'Subprocess' -derivedDataPath .build
   cocoapods:
     name: Pod lib lint
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
+    - run: |
+        sudo xcode-select -s /Applications/Xcode_15.0.app
     - uses: actions/checkout@v3
     - name: Lib lint
       run: pod lib lint --verbose Subprocess.podspec

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,4 +41,4 @@ jobs:
         sudo xcode-select -s /Applications/Xcode_15.0.app
     - uses: actions/checkout@v3
     - name: Lib lint
-      run: pod lib lint --verbose Subprocess.podspec
+      run: pod lib lint --verbose Subprocess.podspec --allow-warnings

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,8 +14,10 @@ concurrency:
 jobs:
   build_docs:
     name: Build and Archive Docs
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
+    - run: |
+        sudo xcode-select -s /Applications/Xcode_15.0.app
     - name: Checkout
       uses: actions/checkout@v3
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,9 @@
+disabled_rules:
+- trailing_whitespace # Xcode automatically adds space for new lines
+- line_length # IDE is good at wrapping long lines
+- function_body_length
+- file_length # doesn't play nice when you need to have private in the same file
+- identifier_name
+- nesting
+- large_tuple
+- colon # doesn't follow Swift formatting

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,7 +3,7 @@ disabled_rules:
 - line_length # IDE is good at wrapping long lines
 - function_body_length
 - file_length # doesn't play nice when you need to have private in the same file
-- identifier_name
 - nesting
 - large_tuple
 - colon # doesn't follow Swift formatting
+- type_body_length # XCTest subclasses and arbitrary depending on type

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 - Breaking: `Subprocess.init` no longer accepts an argument for a dispatch queue's quality of service since the underlying implementation now uses Swift Concurrency and not GCD.
-- `Shell`, `Input` and `SubprocessError` have been deprecated in favor of using new replacement methods that support Swift Concurrency.
+- Breaking: `Input`s `text` case no longer accepts an encoding as utf8 is overwhelmingly common. Instead convert the string to data explicitly if an alternate encoding is required.
+- `Shell` and `SubprocessError` have been deprecated in favor of using new replacement methods that support Swift Concurrency and no longer for a synchronized wait.
 
 ## 2.0.0 - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 - Breaking: `Subprocess.init` no longer accepts an argument for a dispatch queue's quality of service since the underlying implementation now uses Swift Concurrency and not GCD.
 - Breaking: `Input`s `text` case no longer accepts an encoding as utf8 is overwhelmingly common. Instead convert the string to data explicitly if an alternate encoding is required.
-- `Shell` and `SubprocessError` have been deprecated in favor of using new replacement methods that support Swift Concurrency and no longer for a synchronized wait.
+- `Shell` and `SubprocessError` have been deprecated in favor of using new replacement methods that support Swift Concurrency and that no longer have a synchronized wait.
+- Swift 5.9 (Xcode 15) is now the package minimum required to build.
 
 ## 2.0.0 - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 ## Subprocess
 
-Subprocess is a Swift library for macOS providing interfaces for both synchronous and asynchronous process execution. 
+Subprocess is a Swift library for macOS providing interfaces for external process execution. 
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 3.0.0 - 2023-10-13
+
+### Added
+- Methods to `Subprocess` that support Swift Concurrency.
+- `Subprocess.run(standardInput:options:)` can run interactive commands.
+
+### Changed 
+- Breaking: `Subprocess.init` no longer accepts an argument for a dispatch queue's quality of service since the underlying implementation now uses Swift Concurrency and not GCD.
+- `Shell`, `Input` and `SubprocessError` have been deprecated in favor of using new replacement methods that support Swift Concurrency.
 
 ## 2.0.0 - 2021-07-01
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jamf Open Source Community
+Copyright (c) 2023 Jamf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Jamf Open Source Community
+Copyright (c) 2023 Jamf Open Source Community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SwiftDocCPlugin",
-        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
-        "state": {
-          "branch": null,
-          "revision": "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "SymbolKit",
-        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
-        "state": {
-          "branch": null,
-          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
-          "version": "1.0.0"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version: 5.9
 
 import PackageDescription
 
 let package = Package(
     name: "Subprocess",
-    platforms: [ .macOS(.v10_13) ],
+    platforms: [ .macOS("10.15.4") ],
     products: [
         .library(
             name: "Subprocess",
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ Subprocess is a Swift library for macOS providing interfaces for both synchronou
 SubprocessMocks can be used in unit tests for quick and highly customizable mocking and verification of Subprocess usage. 
 
 - [Usage](#usage)
-    - [Shell](#shell-class)
-        - [Input](#command-input) - [Data](#input-for-data), [Text](#input-for-text), [File](#input-for-file-url)
-        - [Output](#command-output) - [Data](#output-as-data), [Text](#output-as-string), [JSON](#output-as-json), [Decodable JSON object](#output-as-decodable-object-from-json), [Property list](#output-as-property-list), [Decodable property list object](#output-as-decodable-object-from-property-list)
-    - [Subprocess](#subprocess-class)
+    - [Subprocess Class](#subprocess-class)
+        - [Command Input](#command-input) - [Data](#input-for-data), [Text](#input-for-text), [File](#input-for-file-url)
+        - [Command Output](#command-output) - [Data](#output-as-data), [Text](#output-as-string), [Decodable JSON object](#output-as-decodable-object-from-json), [Decodable property list object](#output-as-decodable-object-from-property-list)
 - [Installation](#installation)
     - [SwiftPM](#swiftpm)
     - [Cocoapods](#cocoapods)
@@ -133,6 +132,34 @@ if process.exitCode == 0 {
 } else {
     // Handle failure
 }
+```
+###### Closure based callbacks
+```swift
+let command: [String] = ...
+let process = Subprocess(command)
+
+// The outputHandler and errorHandler are invoked serially
+try process.launch(outputHandler: { data in
+    // Handle new data read from stdout
+}, errorHandler: { data in
+    // Handle new data read from stderr
+}, terminationHandler: { process in
+    // Handle process termination, all scheduled calls to
+    // the outputHandler and errorHandler are guaranteed to
+    // have completed.
+})
+```
+###### Handing output on termination with a closure
+```swift
+let command: [String] = ...
+let process = Subprocess(command)
+
+try process.launch { (process, outputData, errorData) in
+    if process.exitCode == 0 {
+        // Do something with output data
+    } else {
+        // Handle failure
+    }
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `Subprocess` class can be used for command execution.
 
 ###### Input for data
 ```swift
-let inputData: Data = "hello world".data(using: .utf8)!
+let inputData = Data("hello world".utf8)
 let data = try await Subprocess.data(for: ["/usr/bin/grep", "hello"], standardInput: inputData)
 ```
 ###### Input for text

--- a/Sources/Subprocess/AsyncSequence+Additions.swift
+++ b/Sources/Subprocess/AsyncSequence+Additions.swift
@@ -1,0 +1,50 @@
+//
+//  AsyncSequence+Additions.swift
+//  Subprocess
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Jamf Software
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+extension AsyncSequence {
+    /// Returns a sequence of all the elements.
+    public func sequence() async rethrows -> [Element] {
+        try await reduce(into: [Element]()) { $0.append($1) }
+    }
+}
+
+extension AsyncSequence where Element == UInt8 {
+    /// Returns a `Data` representation.
+    public func data() async rethrows -> Data {
+        Data(try await sequence())
+    }
+    
+    public func string() async rethrows -> String {
+        if #available(macOS 12.0, *) {
+            String(try await characters.sequence())
+        } else {
+            String(decoding: try await data(), as: UTF8.self)
+        }
+    }
+}

--- a/Sources/Subprocess/AsyncSequence+Additions.swift
+++ b/Sources/Subprocess/AsyncSequence+Additions.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2023 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Subprocess/AsyncStream+Yield.swift
+++ b/Sources/Subprocess/AsyncStream+Yield.swift
@@ -1,0 +1,69 @@
+//
+//  AsyncStream+Yield.swift
+//  Subprocess
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Jamf Software
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+extension AsyncStream.Continuation where Element == UInt8 {
+    /// Resume the task awaiting the next iteration point by having it return
+    /// normally from its suspension point with the given data.
+    ///
+    /// - Parameter value: The value to yield from the continuation.
+    /// - Returns: A `YieldResult` that indicates the success or failure of the
+    ///   yield operation from the last byte of the `Data`.
+    ///
+    /// If nothing is awaiting the next value, this method attempts to buffer the
+    /// result's element.
+    ///
+    /// This can be called more than once and returns to the caller immediately
+    /// without blocking for any awaiting consumption from the iteration.
+    @discardableResult public func yield(_ value: Data) -> AsyncStream<Element>.Continuation.YieldResult? {
+        var yieldResult: AsyncStream<Element>.Continuation.YieldResult?
+        
+        for byte in value {
+            yieldResult = yield(byte)
+        }
+        
+        return yieldResult
+    }
+    
+    /// Resume the task awaiting the next iteration point by having it return
+    /// normally from its suspension point with the given string.
+    ///
+    /// - Parameter value: The value to yield from the continuation.
+    /// - Returns: A `YieldResult` that indicates the success or failure of the
+    ///   yield operation from the last byte of the string after being converted to `Data`.
+    ///
+    /// If nothing is awaiting the next value, this method attempts to buffer the
+    /// result's element.
+    ///
+    /// This can be called more than once and returns to the caller immediately
+    /// without blocking for any awaiting consumption from the iteration.
+    @discardableResult public func yield(_ value: String) -> AsyncStream<Element>.Continuation.YieldResult? {
+        // unicode encodings are safe to explicity unwrap
+        yield(value.data(using: .utf8)!)
+    }
+}

--- a/Sources/Subprocess/AsyncStream+Yield.swift
+++ b/Sources/Subprocess/AsyncStream+Yield.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2023 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Subprocess/Errors.swift
+++ b/Sources/Subprocess/Errors.swift
@@ -28,6 +28,7 @@
 import Foundation
 
 /// Type representing possible errors
+@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
 public enum SubprocessError: Error {
 
     /// The process completed with a non-zero exit code
@@ -47,15 +48,16 @@ public enum SubprocessError: Error {
     case outputStringEncodingError
 }
 
+@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
 extension SubprocessError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .exitedWithNonZeroStatus(_, let errorMessage):
             return "\(errorMessage)"
-        case .unexpectedPropertyListObject(_):
+        case .unexpectedPropertyListObject:
             // Ignoring the plist contents parameter as we don't want that in the error message
             return "The property list object could not be cast to expected type"
-        case .unexpectedJSONObject(_):
+        case .unexpectedJSONObject:
             // Ignoring the json contents parameter as we don't want that in the error message
             return "The JSON object could not be cast to expected type"
         case .inputStringEncodingError:
@@ -67,6 +69,7 @@ extension SubprocessError: LocalizedError {
 }
 
 /// Common NSError methods for better interop with Objective-C
+@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
 extension SubprocessError: CustomNSError {
     public var errorCode: Int {
         switch self {

--- a/Sources/Subprocess/Errors.swift
+++ b/Sources/Subprocess/Errors.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@
 import Foundation
 
 /// Type representing possible errors
-@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
+@available(*, deprecated, message: "This type is no longer used with non-deprecated methods")
 public enum SubprocessError: Error {
 
     /// The process completed with a non-zero exit code
@@ -48,7 +48,7 @@ public enum SubprocessError: Error {
     case outputStringEncodingError
 }
 
-@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
+@available(*, deprecated, message: "This type is no longer used with non-deprecated methods")
 extension SubprocessError: LocalizedError {
     public var errorDescription: String? {
         switch self {
@@ -69,7 +69,7 @@ extension SubprocessError: LocalizedError {
 }
 
 /// Common NSError methods for better interop with Objective-C
-@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
+@available(*, deprecated, message: "This type is no longer used with non-deprecated methods")
 extension SubprocessError: CustomNSError {
     public var errorCode: Int {
         switch self {

--- a/Sources/Subprocess/Input.swift
+++ b/Sources/Subprocess/Input.swift
@@ -27,6 +27,7 @@
 import Foundation
 
 /// Interface representing input to the process
+@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
 public struct Input {
 
     /// Reference to the input value

--- a/Sources/Subprocess/Input.swift
+++ b/Sources/Subprocess/Input.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,9 +27,7 @@
 import Foundation
 
 /// Interface representing input to the process
-@available(*, deprecated, message: "This type is no longer used with methods supporting Swift Concurrency")
 public struct Input {
-
     /// Reference to the input value
     public enum Value {
 
@@ -37,7 +35,7 @@ public struct Input {
         case data(Data)
 
         /// Text to be written to stdin of the child process
-        case text(String, String.Encoding)
+        case text(String)
 
         /// File to be written to stdin of the child process
         case file(URL)
@@ -56,8 +54,8 @@ public struct Input {
     /// Creates input for writing text to stdin of the child process
     /// - Parameter text: Text written to stdin of the child process
     /// - Returns: New Input instance
-    public static func text(_ text: String, encoding: String.Encoding = .utf8) -> Input {
-        return Input(value: .text(text, encoding))
+    public static func text(_ text: String) -> Input {
+        return Input(value: .text(text))
     }
 
     /// Creates input for writing contents of file at path to stdin of the child process
@@ -79,10 +77,15 @@ public struct Input {
     func createPipeOrFileHandle() throws -> Any {
         switch value {
         case .data(let data):
-            return SubprocessDependencyBuilder.shared.makeInputPipe(data: data)
-        case .text(let text, let encoding):
-            guard let data = text.data(using: encoding) else { throw SubprocessError.inputStringEncodingError }
-            return SubprocessDependencyBuilder.shared.makeInputPipe(data: data)
+            return try SubprocessDependencyBuilder.shared.makeInputPipe(sequence: AsyncStream(UInt8.self, { continuation in
+                continuation.yield(data)
+                continuation.finish()
+            }))
+        case .text(let text):
+            return try SubprocessDependencyBuilder.shared.makeInputPipe(sequence: AsyncStream(UInt8.self, { continuation in
+                continuation.yield(Data(text.utf8))
+                continuation.finish()
+            }))
         case .file(let url):
             return try SubprocessDependencyBuilder.shared.makeInputFileHandle(url: url)
         }

--- a/Sources/Subprocess/Pipe+AsyncBytes.swift
+++ b/Sources/Subprocess/Pipe+AsyncBytes.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2023 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Subprocess/Pipe+AsyncBytes.swift
+++ b/Sources/Subprocess/Pipe+AsyncBytes.swift
@@ -1,0 +1,67 @@
+//
+//  Pipe+AsyncBytes.swift
+//  Subprocess
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Jamf Software
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+// `FileHandle.AsyncBytes` has a bug that can block reading of stdout when also reading stderr.
+// We can avoid this problem if we create independent handlers.
+extension Pipe {
+    /// Convenience for reading bytes from the pipe's file handle.
+    public struct AsyncBytes: AsyncSequence {
+        public typealias Element = UInt8
+
+        let pipe: Pipe
+
+        public func makeAsyncIterator() -> AsyncStream<Element>.Iterator {
+            AsyncStream { continuation in
+                pipe.fileHandleForReading.readabilityHandler = { handle in
+                    let availableData = handle.availableData
+                    
+                    guard !availableData.isEmpty else {
+                        handle.readabilityHandler = nil
+                        continuation.finish()
+                        return
+                    }
+                    
+                    for byte in availableData {
+                        if case .terminated = continuation.yield(byte) {
+                            break
+                        }
+                    }
+                }
+
+                continuation.onTermination = { _ in
+                    pipe.fileHandleForReading.readabilityHandler = nil
+                }
+            }.makeAsyncIterator()
+        }
+    }
+
+    public var bytes: AsyncBytes {
+        AsyncBytes(pipe: self)
+    }
+}

--- a/Sources/Subprocess/Shell.swift
+++ b/Sources/Subprocess/Shell.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Subprocess/SubprocessDependencyBuilder.swift
+++ b/Sources/Subprocess/SubprocessDependencyBuilder.swift
@@ -53,7 +53,7 @@ public protocol SubprocessDependencyFactory {
 public struct SubprocessDependencyBuilder: SubprocessDependencyFactory {
     private static let queue = DispatchQueue(label: "\(Self.self)")
     private static var _shared: any SubprocessDependencyFactory = SubprocessDependencyBuilder()
-    /// Shared instance used for dependency creatation
+    /// Shared instance used for dependency creation
     public static var shared: any SubprocessDependencyFactory {
         get {
             queue.sync {

--- a/Sources/Subprocess/SubprocessDependencyBuilder.swift
+++ b/Sources/Subprocess/SubprocessDependencyBuilder.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -41,12 +41,12 @@ public protocol SubprocessDependencyFactory {
     /// - Returns: New FileHandle for reading
     /// - Throws: When unable to open file for reading
     func makeInputFileHandle(url: URL) throws -> FileHandle
-
-    /// Creates a Pipe and writes given data
+    
+    /// Creates a `Pipe` and writes the sequence.
     ///
-    /// - Parameter data: Data to write to the Pipe
-    /// - Returns: New Pipe instance
-    func makeInputPipe(data: Data) -> Pipe
+    /// - Parameter sequence: An `AsyncSequence` that supplies data to be written.
+    /// - Returns: New `Pipe` instance.
+    func makeInputPipe<Input>(sequence: Input) throws -> Pipe where Input : AsyncSequence, Input.Element == UInt8
 }
 
 /// Default implementation of SubprocessDependencyFactory
@@ -79,14 +79,33 @@ public struct SubprocessDependencyBuilder: SubprocessDependencyFactory {
     public func makeInputFileHandle(url: URL) throws -> FileHandle {
         return try FileHandle(forReadingFrom: url)
     }
-
-    public func makeInputPipe(data: Data) -> Pipe {
+    
+    public func makeInputPipe<Input>(sequence: Input) throws -> Pipe where Input : AsyncSequence, Input.Element == UInt8 {
         let pipe = Pipe()
-        pipe.fileHandleForWriting.writeabilityHandler = { handle in
-            handle.write(data)
-            handle.writeabilityHandler = nil
-            try? handle.close()
+        // see here: https://developer.apple.com/forums/thread/690382
+        let result = fcntl(pipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+        
+        guard result >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(result), userInfo: nil)
         }
+        
+        pipe.fileHandleForWriting.writeabilityHandler = { handle in
+            handle.writeabilityHandler = nil
+
+            Task {
+                defer {
+                    try? handle.close()
+                }
+                
+                // `DispatchIO` seems like an interesting solution but doesn't seem to mesh well with async/await, perhaps there will be updates in this area in the future.
+                // https://developer.apple.com/forums/thread/690310
+                // According to Swift forum talk byte by byte reads _could_ be optimized by the compiler depending on how much visibility it has into methods.
+                for try await byte in sequence {
+                    try handle.write(contentsOf: [byte])
+                }
+            }
+        }
+        
         return pipe
     }
 }

--- a/Sources/Subprocess/UnsafeData.swift
+++ b/Sources/Subprocess/UnsafeData.swift
@@ -1,0 +1,45 @@
+//
+//  UnsafeData.swift
+//  Subprocess
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Jamf Software
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+// Avoids errors for modifying data in concurrent contexts when we know it's safe to do so.
+final class UnsafeData: @unchecked Sendable {
+    private lazy var data = Data()
+    
+    func set(_ data: Data) {
+        self.data = data
+    }
+    
+    func append(_ other: Data) {
+        data.append(other)
+    }
+    
+    func value() -> Data {
+        data
+    }
+}

--- a/Sources/Subprocess/UnsafeData.swift
+++ b/Sources/Subprocess/UnsafeData.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2023 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SubprocessMocks/MockOutput.swift
+++ b/Sources/SubprocessMocks/MockOutput.swift
@@ -1,6 +1,6 @@
 //
-//  Subprocess.h
-//  Subprocess
+//  MockOutput.swift
+//  SubprocessMocks
 //
 //  MIT License
 //
@@ -25,10 +25,21 @@
 //  SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+import Foundation
 
-//! Project version number for Subprocess.
-FOUNDATION_EXPORT double SubprocessVersionNumber;
+/// A way to supply data to mock methods
+public protocol MockOutput {
+    var data: Data { get }
+}
 
-//! Project version string for Subprocess.
-FOUNDATION_EXPORT const unsigned char SubprocessVersionString[];
+extension Data: MockOutput {
+    public var data: Data {
+        self
+    }
+}
+
+extension String: MockOutput {
+    public var data: Data {
+        Data(self.utf8)
+    }
+}

--- a/Sources/SubprocessMocks/MockShell.swift
+++ b/Sources/SubprocessMocks/MockShell.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SubprocessMocks/MockShell.swift
+++ b/Sources/SubprocessMocks/MockShell.swift
@@ -30,8 +30,10 @@ import Foundation
 import Subprocess
 #endif
 
+@available(*, deprecated, message: "Swift Concurrency methods in Subprocess replace Shell")
 extension Shell: SubprocessMockObject {}
 
+@available(*, deprecated, message: "Swift Concurrency methods in Subprocess replace Shell")
 public extension Shell {
 
     /// Adds a mock for a command which throws an error when `Process.run` is called
@@ -39,7 +41,7 @@ public extension Shell {
     /// - Parameters:
     ///     - command: The command to mock
     ///     - error: Error thrown when `Process.run` is called
-    static func stub(_ command: [String], error: Error) {
+    static func stub(_ command: [String], error: any Error) {
         Subprocess.stub(command, error: error)
     }
 
@@ -171,7 +173,7 @@ public extension Shell {
     ///     - line: Line number of source file where expect was called (Default: #line)
     static func expect(_ command: [String],
                        input: Input? = nil,
-                       error: Error,
+                       error: any Swift.Error,
                        file: StaticString = #file,
                        line: UInt = #line) {
         Subprocess.expect(command, input: input, error: error, file: file, line: line)

--- a/Sources/SubprocessMocks/MockSubprocess.swift
+++ b/Sources/SubprocessMocks/MockSubprocess.swift
@@ -39,7 +39,7 @@ public extension Subprocess {
     /// - Parameters:
     ///     - command: The command to mock
     ///     - error: Error thrown when `Process.run` is called
-    static func stub(_ command: [String], error: Error) {
+    static func stub(_ command: [String], error: any Swift.Error) {
         let mock = MockProcessReference(withRunError: error)
         MockSubprocessDependencyBuilder.shared.stub(command, process: mock)
     }
@@ -65,7 +65,7 @@ public extension Subprocess {
     ///     - line: Line number of source file where expect was called (Default: #line)
     static func expect(_ command: [String],
                        input: Input? = nil,
-                       error: Error,
+                       error: any Swift.Error,
                        file: StaticString = #file,
                        line: UInt = #line) {
         let mock = MockProcessReference(withRunError: error)

--- a/Sources/SubprocessMocks/MockSubprocess.swift
+++ b/Sources/SubprocessMocks/MockSubprocess.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 //
 
 import Foundation
+import Combine
 #if !COCOA_PODS
 import Subprocess
 #endif
@@ -54,6 +55,44 @@ public extension Subprocess {
         let mock = MockProcessReference(withRunBlock: runBlock ?? { $0.exit() })
         MockSubprocessDependencyBuilder.shared.stub(command, process: mock)
     }
+    
+    /// Adds a mock for a command which writes the given data to the outputs and exits with the provided exit code
+    ///
+    /// - Parameters:
+    ///     - command: The command to mock
+    ///     - standardOutput: Data written to stdout of the process
+    ///     - standardError: Data written to stderr of the process
+    ///     - exitCode: Exit code of the process (Default: 0)
+    static func stub(_ command: [String], standardOutput: (any MockOutput)? = nil, standardError: (any MockOutput)? = nil, exitCode: Int32 = 0) {
+        stub(command) { process in
+            if let data = standardOutput {
+                process.writeTo(stdout: data)
+            }
+            
+            if let data = standardError {
+                process.writeTo(stderr: data)
+            }
+            
+            process.exit(withStatus: exitCode)
+        }
+    }
+    
+    /// Adds a mock for a command which writes the given encodable object as JSON to stdout
+    /// and exits with the provided exit code
+    ///
+    /// - Parameters:
+    ///     - command: The command to mock
+    ///     - content: Encodable object written to stdout
+    ///     - encoder: `TopLevelEncoder` used to encoder `content` into `Data`.
+    ///     - exitCode: Exit code of the process (Default: 0)
+    /// - Throws: Error when encoding the provided object
+    static func stub<Content, Encoder>(_ command: [String], content: Content, encoder: Encoder, exitCode: Int32 = 0) throws where Content : Encodable, Encoder : TopLevelEncoder, Encoder.Output == Data {
+        let data: Data = try encoder.encode(content)
+        
+        stub(command, standardOutput: data, exitCode: exitCode)
+    }
+    
+    // MARK: -
 
     /// Adds an expected mock for a given command which throws an error when `Process.run` is called
     ///
@@ -63,11 +102,7 @@ public extension Subprocess {
     ///     - error: Error thrown when `Process.run` is called
     ///     - file: Source file where expect was called (Default: #file)
     ///     - line: Line number of source file where expect was called (Default: #line)
-    static func expect(_ command: [String],
-                       input: Input? = nil,
-                       error: any Swift.Error,
-                       file: StaticString = #file,
-                       line: UInt = #line) {
+    static func expect(_ command: [String], input: Input? = nil, error: any Swift.Error, file: StaticString = #file, line: UInt = #line) {
         let mock = MockProcessReference(withRunError: error)
         MockSubprocessDependencyBuilder.shared.expect(command, input: input, process: mock, file: file, line: line)
     }
@@ -81,12 +116,44 @@ public extension Subprocess {
     ///     - file: Source file where expect was called (Default: #file)
     ///     - line: Line number of source file where expect was called (Default: #line)
     ///     - runBlock: Block called with a `MockProcess` to mock process execution
-    static func expect(_ command: [String],
-                       input: Input? = nil,
-                       file: StaticString = #file,
-                       line: UInt = #line,
-                       runBlock: ((MockProcess) -> Void)? = nil) {
+    static func expect(_ command: [String], input: Input? = nil, file: StaticString = #file, line: UInt = #line, runBlock: ((MockProcess) -> Void)? = nil) {
         let mock = MockProcessReference(withRunBlock: runBlock ?? { $0.exit() })
         MockSubprocessDependencyBuilder.shared.expect(command, input: input, process: mock, file: file, line: line)
+    }
+    
+    /// Adds a mock for a command which writes the given data to the outputs and exits with the provided exit code
+    ///
+    /// - Parameters:
+    ///     - command: The command to mock
+    ///     - standardOutput: Data written to stdout of the process
+    ///     - standardError: Data written to stderr of the process
+    ///     - exitCode: Exit code of the process (Default: 0)
+    static func expect(_ command: [String], standardOutput: (any MockOutput)? = nil, standardError: (any MockOutput)? = nil, input: Input? = nil, exitCode: Int32 = 0, file: StaticString = #file, line: UInt = #line) {
+        expect(command, input: input, file: file, line: line) { process in
+            if let data = standardOutput {
+                process.writeTo(stdout: data)
+            }
+            
+            if let data = standardError {
+                process.writeTo(stderr: data)
+            }
+            
+            process.exit(withStatus: exitCode)
+        }
+    }
+    
+    /// Adds a mock for a command which writes the given encodable object as JSON to stdout
+    /// and exits with the provided exit code
+    ///
+    /// - Parameters:
+    ///     - command: The command to mock
+    ///     - content: Encodable object written to stdout
+    ///     - encoder: `TopLevelEncoder` used to encoder `content` into `Data`.
+    ///     - exitCode: Exit code of the process (Default: 0)
+    /// - Throws: Error when encoding the provided object
+    static func expect<Content, Encoder>(_ command: [String], content: Content, encoder: Encoder, input: Input? = nil, exitCode: Int32 = 0, file: StaticString = #file, line: UInt = #line) throws where Content : Encodable, Encoder : TopLevelEncoder, Encoder.Output == Data {
+        let data: Data = try encoder.encode(content)
+        
+        expect(command, standardOutput: data, input: input, exitCode: exitCode, file: file, line: line)
     }
 }

--- a/Sources/SubprocessMocks/SubprocessMocks.h
+++ b/Sources/SubprocessMocks/SubprocessMocks.h
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2018 Jamf Software
+//  Copyright (c) 2023 Jamf
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Subprocess.podspec
+++ b/Subprocess.podspec
@@ -1,17 +1,17 @@
 Pod::Spec.new do |s|
   s.name         = 'Subprocess'
-  s.version      = '2.0.0'
+  s.version      = '3.0.0'
   s.summary      = 'Wrapper for NSTask used for running processes and shell commands on macOS.'
   s.license      = { :type => 'MIT', :text => "" }
   s.description  = <<-DESC
                     Everything related to creating processes and running shell commands on macOS.
                    DESC
   s.homepage     = 'https://github.com/jamf/Subprocess'
-  s.authors      = { 'Cyrus Ingraham' => 'cyrus.ingraham@jamf.com' }
+  s.authors      = { 'Cyrus Ingraham' => 'cyrus.ingraham@jamf.com', 'Michael Link' => 'michael.link@jamf.com' }
   s.source       = { :git => "https://github.com/jamf/Subprocess.git", :tag => s.version.to_s }
-  s.platform = :osx, '10.13'
-  s.osx.deployment_target = '10.13'
-  s.swift_version = '5.1'
+  s.platform = :osx, '10.15.4'
+  s.osx.deployment_target = '10.15.4'
+  s.swift_version = '5.9'
   s.default_subspec = 'Core'
 
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DCOCOA_PODS' }

--- a/Subprocess.podspec
+++ b/Subprocess.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
                     Everything related to creating processes and running shell commands on macOS.
                    DESC
   s.homepage     = 'https://github.com/jamf/Subprocess'
-  s.authors      = { 'Cyrus Ingraham' => 'cyrus.ingraham@jamf.com', 'Michael Link' => 'michael.link@jamf.com' }
+  s.authors      = { 'Michael Link' => 'michael.link@jamf.com' }
   s.source       = { :git => "https://github.com/jamf/Subprocess.git", :tag => s.version.to_s }
   s.platform = :osx, '10.15.4'
   s.osx.deployment_target = '10.15.4'

--- a/Subprocess.xcodeproj/project.pbxproj
+++ b/Subprocess.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -25,6 +25,11 @@
 		6EDDC6FC2410396000E171C6 /* ShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDC6BD2410378100E171C6 /* ShellTests.swift */; };
 		6EDDC6FD24105F8300E171C6 /* SubprocessMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EDDC6CB241037CE00E171C6 /* SubprocessMocks.framework */; };
 		6EDDC6FE24105F8700E171C6 /* Subprocess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EDDC6382410369400E171C6 /* Subprocess.framework */; };
+		8F6AA3F62ADDA80000F86C7A /* UnsafeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F22ADDA80000F86C7A /* UnsafeData.swift */; };
+		8F6AA3F72ADDA80000F86C7A /* AsyncStream+Yield.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F32ADDA80000F86C7A /* AsyncStream+Yield.swift */; };
+		8F6AA3F82ADDA80000F86C7A /* AsyncSequence+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F42ADDA80000F86C7A /* AsyncSequence+Additions.swift */; };
+		8F6AA3F92ADDA80000F86C7A /* Pipe+AsyncBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F52ADDA80000F86C7A /* Pipe+AsyncBytes.swift */; };
+		8F6AA3FC2ADDA85C00F86C7A /* SubprocessSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3FA2ADDA85500F86C7A /* SubprocessSystemTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +76,11 @@
 		6EDDC6CB241037CE00E171C6 /* SubprocessMocks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SubprocessMocks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EDDC6E02410391500E171C6 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EDDC6EF2410392400E171C6 /* SystemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SystemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F6AA3F22ADDA80000F86C7A /* UnsafeData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnsafeData.swift; sourceTree = "<group>"; };
+		8F6AA3F32ADDA80000F86C7A /* AsyncStream+Yield.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AsyncStream+Yield.swift"; sourceTree = "<group>"; };
+		8F6AA3F42ADDA80000F86C7A /* AsyncSequence+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AsyncSequence+Additions.swift"; sourceTree = "<group>"; };
+		8F6AA3F52ADDA80000F86C7A /* Pipe+AsyncBytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Pipe+AsyncBytes.swift"; sourceTree = "<group>"; };
+		8F6AA3FA2ADDA85500F86C7A /* SubprocessSystemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubprocessSystemTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,11 +158,15 @@
 			children = (
 				6EDDC6A52410378100E171C6 /* Subprocess.swift */,
 				6EDDC6A62410378100E171C6 /* SubprocessDependencyBuilder.swift */,
-				6EDDC6A72410378100E171C6 /* Shell.swift */,
+				8F6AA3F42ADDA80000F86C7A /* AsyncSequence+Additions.swift */,
+				8F6AA3F32ADDA80000F86C7A /* AsyncStream+Yield.swift */,
+				8F6AA3F52ADDA80000F86C7A /* Pipe+AsyncBytes.swift */,
+				8F6AA3F22ADDA80000F86C7A /* UnsafeData.swift */,
+				6E1195E32416630500534F74 /* Input.swift */,
 				6EDDC6A82410378100E171C6 /* Errors.swift */,
+				6EDDC6A72410378100E171C6 /* Shell.swift */,
 				6EDDC6A92410378100E171C6 /* Subprocess.h */,
 				6EDDC6AA2410378100E171C6 /* Info.plist */,
-				6E1195E32416630500534F74 /* Input.swift */,
 			);
 			path = Subprocess;
 			sourceTree = "<group>";
@@ -182,6 +196,7 @@
 		6EDDC6B52410378100E171C6 /* SystemTests */ = {
 			isa = PBXGroup;
 			children = (
+				8F6AA3FA2ADDA85500F86C7A /* SubprocessSystemTests.swift */,
 				6EDDC6B82410378100E171C6 /* ShellSystemTests.swift */,
 				6EDDC6B92410378100E171C6 /* Info.plist */,
 			);
@@ -307,8 +322,9 @@
 		6EDDC62F2410369400E171C6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = Jamf;
 				TargetAttributes = {
 					6EDDC6372410369400E171C6 = {
@@ -381,6 +397,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		6E1195E124165F1500534F74 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -394,10 +411,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		6E1195E224165F2000534F74 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -411,7 +429,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi \n";
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -421,9 +439,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E1195E42416630500534F74 /* Input.swift in Sources */,
+				8F6AA3F92ADDA80000F86C7A /* Pipe+AsyncBytes.swift in Sources */,
+				8F6AA3F82ADDA80000F86C7A /* AsyncSequence+Additions.swift in Sources */,
 				6EDDC6C42410379F00E171C6 /* Errors.swift in Sources */,
 				6EDDC6C32410379F00E171C6 /* Shell.swift in Sources */,
+				8F6AA3F62ADDA80000F86C7A /* UnsafeData.swift in Sources */,
 				6EDDC6C22410379F00E171C6 /* SubprocessDependencyBuilder.swift in Sources */,
+				8F6AA3F72ADDA80000F86C7A /* AsyncStream+Yield.swift in Sources */,
 				6EDDC6C12410379F00E171C6 /* Subprocess.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +475,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6EDDC6F92410395800E171C6 /* ShellSystemTests.swift in Sources */,
+				8F6AA3FC2ADDA85C00F86C7A /* SubprocessSystemTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -507,6 +530,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -524,7 +548,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -571,6 +595,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -582,7 +607,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -599,11 +624,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Sources/Subprocess/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -611,6 +638,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.opensource.subprocess.Subprocess;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -626,11 +655,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Sources/Subprocess/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -638,6 +669,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.opensource.subprocess.Subprocess;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -651,11 +684,13 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Sources/SubprocessMocks/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -663,6 +698,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.opensource.subprocess.SubprocessMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -676,11 +713,13 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Sources/SubprocessMocks/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -688,6 +727,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.opensource.subprocess.SubprocessMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -701,6 +742,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = Tests/UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -718,6 +760,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = Tests/UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -735,6 +778,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = Tests/SystemTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -752,6 +796,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = Tests/SystemTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Subprocess.xcodeproj/project.pbxproj
+++ b/Subprocess.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		8F6AA3F82ADDA80000F86C7A /* AsyncSequence+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F42ADDA80000F86C7A /* AsyncSequence+Additions.swift */; };
 		8F6AA3F92ADDA80000F86C7A /* Pipe+AsyncBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3F52ADDA80000F86C7A /* Pipe+AsyncBytes.swift */; };
 		8F6AA3FC2ADDA85C00F86C7A /* SubprocessSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA3FA2ADDA85500F86C7A /* SubprocessSystemTests.swift */; };
+		8F95A1182AE1F8A3008958DD /* MockOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95A1172AE1F8A3008958DD /* MockOutput.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		8F6AA3F42ADDA80000F86C7A /* AsyncSequence+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AsyncSequence+Additions.swift"; sourceTree = "<group>"; };
 		8F6AA3F52ADDA80000F86C7A /* Pipe+AsyncBytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Pipe+AsyncBytes.swift"; sourceTree = "<group>"; };
 		8F6AA3FA2ADDA85500F86C7A /* SubprocessSystemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubprocessSystemTests.swift; sourceTree = "<group>"; };
+		8F95A1172AE1F8A3008958DD /* MockOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOutput.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,8 +180,9 @@
 				6EDDC6AD2410378100E171C6 /* MockSubprocess.swift */,
 				6EDDC6AE2410378100E171C6 /* MockShell.swift */,
 				6EDDC6AF2410378100E171C6 /* MockSubprocessDependencyBuilder.swift */,
-				6EDDC6B02410378100E171C6 /* Info.plist */,
 				6EDDC6B12410378100E171C6 /* MockProcess.swift */,
+				8F95A1172AE1F8A3008958DD /* MockOutput.swift */,
+				6EDDC6B02410378100E171C6 /* Info.plist */,
 			);
 			path = SubprocessMocks;
 			sourceTree = "<group>";
@@ -456,6 +459,7 @@
 			files = (
 				6EDDC6D9241037F500E171C6 /* MockShell.swift in Sources */,
 				6EDDC6DB241037F500E171C6 /* MockProcess.swift in Sources */,
+				8F95A1182AE1F8A3008958DD /* MockOutput.swift in Sources */,
 				6EDDC6D8241037F500E171C6 /* MockSubprocess.swift in Sources */,
 				6EDDC6DA241037F500E171C6 /* MockSubprocessDependencyBuilder.swift in Sources */,
 			);

--- a/Subprocess.xcodeproj/xcshareddata/xcschemes/Subprocess.xcscheme
+++ b/Subprocess.xcodeproj/xcshareddata/xcschemes/Subprocess.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Subprocess.xcodeproj/xcshareddata/xcschemes/SubprocessMocks.xcscheme
+++ b/Subprocess.xcodeproj/xcshareddata/xcschemes/SubprocessMocks.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/SystemTests/ShellSystemTests.swift
+++ b/Tests/SystemTests/ShellSystemTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Subprocess
 
+@available(*, deprecated, message: "Swift Concurrency methods in Subprocess replace Shell")
 final class ShellSystemTests: XCTestCase {
 
     override func setUp() {
@@ -73,7 +74,7 @@ final class ShellSystemTests: XCTestCase {
         var result: [[String: Any]]?
 
         // When
-        XCTAssertNoThrow(result = try Shell(["/usr/bin/log", "show", "--style", "json", "--last", "5m"]).execJSON())
+        XCTAssertNoThrow(result = try Shell(["/usr/bin/log", "show", "--style", "json", "--last", "1m"]).execJSON())
 
         // Then
         XCTAssertFalse(result?.isEmpty ?? true)
@@ -106,7 +107,7 @@ final class ShellSystemTests: XCTestCase {
             var machTimestamp: UInt64
         }
         var result: [LogMessage]?
-        let cmd = ["/usr/bin/log", "show", "--style", "json", "--last", "5m"]
+        let cmd = ["/usr/bin/log", "show", "--style", "json", "--last", "1m"]
         // When
         XCTAssertNoThrow(result = try Shell(cmd).exec(decoder: JSONDecoder()))
 

--- a/Tests/SystemTests/SubprocessSystemTests.swift
+++ b/Tests/SystemTests/SubprocessSystemTests.swift
@@ -10,14 +10,14 @@ final class SubprocessSystemTests: XCTestCase {
     
     @available(macOS 12.0, *)
     func testRunWithOutput() async throws {
-        let result = try await Subprocess(["/usr/bin/csrutil", "status"]).run().standardOutput.lines.first(where: { $0.contains("enabled") }) != nil
+        let result = try await Subprocess(["/bin/cat", softwareVersionFilePath]).run().standardOutput.lines.first(where: { $0.contains("ProductName") }) != nil
         
         XCTAssertTrue(result)
     }
     
     @available(macOS 12.0, *)
     func testRunWithStandardOutput() async throws {
-        let result = try await Subprocess(["/usr/bin/csrutil", "status"]).run(options: .standardOutput).standardOutput.lines.first(where: { $0.contains("enabled") }) != nil
+        let result = try await Subprocess(["/bin/cat", softwareVersionFilePath]).run(options: .standardOutput).standardOutput.lines.first(where: { $0.contains("ProductName") }) != nil
         
         XCTAssertTrue(result)
     }
@@ -30,13 +30,13 @@ final class SubprocessSystemTests: XCTestCase {
     }
     
     func testRunWithCombinedOutput() async throws {
-        let process = Subprocess(["/usr/bin/csrutil", "status"])
+        let process = Subprocess(["/bin/cat", softwareVersionFilePath])
         let (standardOutput, standardError, waitForExit) = try process.run()
         async let (stdout, stderr) = (standardOutput, standardError)
         let combinedOutput = await [stdout.string(), stderr.string()]
         
         await waitForExit()
-        XCTAssertTrue(combinedOutput[0].contains("enabled"))
+        XCTAssertTrue(combinedOutput[0].contains("ProductName"))
     }
     
     @available(macOS 12.0, *)

--- a/Tests/SystemTests/SubprocessSystemTests.swift
+++ b/Tests/SystemTests/SubprocessSystemTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import Subprocess
+
+final class SubprocessSystemTests: XCTestCase {
+    let softwareVersionFilePath = "/System/Library/CoreServices/SystemVersion.plist"
+    
+    @available(macOS 12.0, *)
+    func testRunWithOutput() async throws {
+        let result = try await Subprocess(["/usr/bin/csrutil", "status"]).run().standardOutput.lines.first(where: { $0.contains("enabled") }) != nil
+        
+        XCTAssertTrue(result)
+    }
+    
+    @available(macOS 12.0, *)
+    func testRunWithStandardOutput() async throws {
+        let result = try await Subprocess(["/usr/bin/csrutil", "status"]).run(options: .standardOutput).standardOutput.lines.first(where: { $0.contains("enabled") }) != nil
+        
+        XCTAssertTrue(result)
+    }
+    
+    @available(macOS 12.0, *)
+    func testRunWithStandardError() async throws {
+        let result = try await Subprocess(["/bin/cat", "/non/existent/path/file.txt"]).run(options: .standardError).standardError.lines.first(where: { $0.contains("No such file or directory") }) != nil
+        
+        XCTAssertTrue(result)
+    }
+    
+    func testRunWithCombinedOutput() async throws {
+        let process = Subprocess(["/usr/bin/csrutil", "status"])
+        let (standardOutput, standardError, waitForExit) = try process.run()
+        async let (stdout, stderr) = (standardOutput, standardError)
+        let combinedOutput = await [stdout.string(), stderr.string()]
+        
+        await waitForExit()
+        XCTAssertTrue(combinedOutput[0].contains("enabled"))
+    }
+    
+    @available(macOS 12.0, *)
+    func testInteractiveRun() async throws {
+        var input: AsyncStream<UInt8>.Continuation!
+        let stream: AsyncStream<UInt8> = AsyncStream { continuation in
+            input = continuation
+        }
+        let subprocess = Subprocess(["/bin/cat"])
+        let (standardOutput, _, _) = try subprocess.run(standardInput: stream)
+        
+        input.yield("hello\n")
+        
+        for await line in standardOutput.lines {
+            XCTAssertEqual("hello", line)
+            break
+        }
+        
+        input.yield("world\n")
+        input.finish()
+        
+        for await line in standardOutput.lines {
+            XCTAssertEqual("world", line)
+            break
+        }
+    }
+    
+    @available(macOS 12.0, *)
+    func testInteractiveAsyncRun() throws {
+        let e = expectation(description: "\(#file):\(#line)")
+        let (stream, input) = {
+            var input: AsyncStream<UInt8>.Continuation!
+            let stream: AsyncStream<UInt8> = AsyncStream { continuation in
+                input = continuation
+            }
+            
+            return (stream, input!)
+        }()
+        
+        let subprocess = Subprocess(["/bin/cat"])
+        let (standardOutput, _, _) = try subprocess.run(standardInput: stream)
+        
+        input.yield("hello\n")
+        
+        Task {
+            for await line in standardOutput.lines {
+                switch line {
+                case "hello":
+                    Task {
+                        input.yield("world\n")
+                    }
+                case "world":
+                    input.yield("and\nuniverse")
+                    input.finish()
+                case "universe":
+                    break
+                default:
+                    continue
+                }
+            }
+            
+            e.fulfill()
+        }
+
+        wait(for: [e])
+    }
+    
+    func testData() async throws {
+        let data = try await Subprocess.data(for: ["/bin/cat", softwareVersionFilePath])
+        
+        XCTAssert(!data.isEmpty)
+    }
+    
+    func testDataWithInput() async throws {
+        let data = try await Subprocess.data(for: ["/bin/cat"], standardInput: "hello".data(using: .utf8)!)
+        
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "hello")
+    }
+    
+    @available(macOS 13.0, *)
+    func testDataCancel() async throws {
+        let e = expectation(description: "\(#file):\(#line)")
+        let task = Task {
+            do {
+                _ = try await Subprocess.data(for: ["/bin/cat"], standardInput: URL(filePath: "/dev/random"))
+                
+                XCTFail("expected task to be canceled")
+            } catch {
+                e.fulfill()
+            }
+        }
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        task.cancel()
+        await fulfillment(of: [e])
+    }
+    
+    func testDataCancelWithoutInput() async throws {
+        let e = expectation(description: "\(#file):\(#line)")
+        let task = Task {
+            do {
+                _ = try await Subprocess.data(for: ["/bin/cat", "/dev/random"])
+                
+                XCTFail("expected task to be canceled")
+            } catch {
+                e.fulfill()
+            }
+        }
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        task.cancel()
+        await fulfillment(of: [e])
+    }
+    
+    func testString() async throws {
+        let username = NSUserName()
+        let result = try await Subprocess.string(for: ["/usr/bin/dscl", ".", "list", "/Users"])
+        
+        XCTAssertTrue(result.contains(username))
+    }
+    
+    func testStringWithStringInput() async throws {
+        let result = try await Subprocess.string(for: ["/bin/cat"], standardInput: "hello")
+        
+        XCTAssertEqual("hello", result)
+    }
+    
+    @available(macOS 13.0, *)
+    func testStringWithFileInput() async throws {
+        let result = try await Subprocess.string(for: ["/bin/cat"], standardInput: URL(filePath: softwareVersionFilePath))
+        
+        XCTAssertEqual(try String(contentsOf: URL(filePath: softwareVersionFilePath)), result)
+    }
+    
+    func testReturningJSON() async throws {
+        struct LogMessage: Codable {
+            var subsystem: String
+            var category: String
+            var machTimestamp: UInt64
+        }
+
+        let result: [LogMessage] = try await Subprocess.value(for: ["/usr/bin/log", "show", "--style", "json", "--last", "30s"], decoder: JSONDecoder())
+        
+        XCTAssertTrue(!result.isEmpty)
+    }
+    
+    func testReturningPropertyList() async throws {
+        struct SystemVersion: Codable {
+            enum CodingKeys: String, CodingKey {
+                case version = "ProductVersion"
+            }
+            var version: String
+        }
+
+        let fullVersionString = ProcessInfo.processInfo.operatingSystemVersionString
+        let result: SystemVersion = try await Subprocess.value(for: ["/bin/cat", softwareVersionFilePath], decoder: PropertyListDecoder())
+        let versionNumber = result.version
+        
+        XCTAssertTrue(fullVersionString.contains(versionNumber))
+    }
+    
+    func testNonZeroExit() async {
+        do {
+            _ = try await Subprocess.string(for: ["/bin/cat", "/non/existent/path/file.txt"])
+            XCTFail("expected failure")
+        } catch Subprocess.Error.nonZeroExit {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/SystemTests/SubprocessSystemTests.swift
+++ b/Tests/SystemTests/SubprocessSystemTests.swift
@@ -66,7 +66,7 @@ final class SubprocessSystemTests: XCTestCase {
     
     @available(macOS 12.0, *)
     func testInteractiveAsyncRun() throws {
-        let e = expectation(description: "\(#file):\(#line)")
+        let exp = expectation(description: "\(#file):\(#line)")
         let (stream, input) = {
             var input: AsyncStream<UInt8>.Continuation!
             let stream: AsyncStream<UInt8> = AsyncStream { continuation in
@@ -98,10 +98,10 @@ final class SubprocessSystemTests: XCTestCase {
                 }
             }
             
-            e.fulfill()
+            exp.fulfill()
         }
 
-        wait(for: [e])
+        wait(for: [exp])
     }
     
     func testData() async throws {
@@ -111,44 +111,44 @@ final class SubprocessSystemTests: XCTestCase {
     }
     
     func testDataWithInput() async throws {
-        let data = try await Subprocess.data(for: ["/bin/cat"], standardInput: "hello".data(using: .utf8)!)
+        let data = try await Subprocess.data(for: ["/bin/cat"], standardInput: Data("hello".utf8))
         
         XCTAssertEqual(String(decoding: data, as: UTF8.self), "hello")
     }
     
     @available(macOS 13.0, *)
     func testDataCancel() async throws {
-        let e = expectation(description: "\(#file):\(#line)")
+        let exp = expectation(description: "\(#file):\(#line)")
         let task = Task {
             do {
                 _ = try await Subprocess.data(for: ["/bin/cat"], standardInput: URL(filePath: "/dev/random"))
                 
                 XCTFail("expected task to be canceled")
             } catch {
-                e.fulfill()
+                exp.fulfill()
             }
         }
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         task.cancel()
-        await fulfillment(of: [e])
+        await fulfillment(of: [exp])
     }
     
     func testDataCancelWithoutInput() async throws {
-        let e = expectation(description: "\(#file):\(#line)")
+        let exp = expectation(description: "\(#file):\(#line)")
         let task = Task {
             do {
                 _ = try await Subprocess.data(for: ["/bin/cat", "/dev/random"])
                 
                 XCTFail("expected task to be canceled")
             } catch {
-                e.fulfill()
+                exp.fulfill()
             }
         }
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         task.cancel()
-        await fulfillment(of: [e])
+        await fulfillment(of: [exp])
     }
     
     func testString() async throws {

--- a/Tests/SystemTests/SubprocessSystemTests.swift
+++ b/Tests/SystemTests/SubprocessSystemTests.swift
@@ -4,6 +4,10 @@ import XCTest
 final class SubprocessSystemTests: XCTestCase {
     let softwareVersionFilePath = "/System/Library/CoreServices/SystemVersion.plist"
     
+    override func setUp() {
+        SubprocessDependencyBuilder.shared = SubprocessDependencyBuilder()
+    }
+    
     @available(macOS 12.0, *)
     func testRunWithOutput() async throws {
         let result = try await Subprocess(["/usr/bin/csrutil", "status"]).run().standardOutput.lines.first(where: { $0.contains("enabled") }) != nil

--- a/Tests/UnitTests/ShellTests.swift
+++ b/Tests/UnitTests/ShellTests.swift
@@ -9,7 +9,8 @@ struct TestCodableObject: Codable, Equatable {
     init() { uuid = UUID() }
 }
 
-// swiftlint:disable control_statement
+// swiftlint:disable control_statement duplicated_key_in_dictionary_literal
+@available(*, deprecated, message: "Swift Concurrency methods in Subprocess replace Shell")
 final class ShellTests: XCTestCase {
 
     let command = [ "/usr/local/bin/somefakeCommand", "foo", "bar" ]
@@ -354,4 +355,4 @@ final class ShellTests: XCTestCase {
         Shell.verify { XCTFail($0.message, file: $0.file, line: $0.line) }
     }
 }
-// swiftlint:enable control_statement
+// swiftlint:enable control_statement duplicated_key_in_dictionary_literal


### PR DESCRIPTION
Adds support for running commands that can be awaited on and deprecates previous non-async closure based methods. 

Only one breaking change for `Subprocess.init` which no longer takes a QOS argument since the underlying implementation now uses Swift Concurrency instead of GCD. This version should be tagged as a major update: `3.0.0`.

Subprocess methods return `AsyncSequence` which can use familiar Swift sequence operators (e.g. `map`, `filter`, etc).

`Shell` has been deprecated in favor of replacement static convenience methods added as extensions to `Subprocess`. One less class to remember.

Other miscellaneous changes and updates that feel more inline with Swift best practices since the last release of this package. Minimum version has been bumped to `10.15.4` in order to use non-objective-c exception throwing methods on `FileHandle`.