### PR TITLE
AEGIS-10939 clarify scope of legacy XCTesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-05-11
+
+### Added
+- `SubprocessMockObject` now provides a `setupMockBuilder()` static method (e.g. `Shell.setupMockBuilder()`, `Subprocess.setupMockBuilder()`) to wire up the mock dependency builder, replacing direct assignment to `SubprocessDependencyBuilder.shared`.
+
+### Changed
+- `SubprocessMockObject.reset()` now also restores `SubprocessDependencyBuilder.shared` to a real instance, so XCTest `tearDown` no longer needs to do it manually.
+- `SubprocessMocks` imports `Subprocess` with `@testable` to expose internal APIs required for mocking.
+- `.subprocessTesting` trait on `Trait where Self == SubprocessTrait` is deprecated and renamed to `.subprocess`.
+
 ## [4.0.0] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Add `SubprocessMocks` and `SubprocessTesting` as dependencies of your test targe
 
 `SubprocessTrait` is a Swift Testing `TestTrait` and `SuiteTrait` that automatically scopes subprocess mocking to each test. Each test gets its own isolated `MockSubprocessDependencyBuilder` via `@TaskLocal`, so tests can safely run in parallel without interfering with each other.
 
-Apply `.subprocessTesting` to any `@Test` or `@Suite`:
+Apply `.subprocess` to any `@Test` or `@Suite`:
 
 ```swift
 import Testing
@@ -212,7 +212,7 @@ import Subprocess
 import SubprocessMocks
 import SubprocessTesting
 
-@Test(.subprocessTesting)
+@Test(.subprocess)
 func testSoftwareVersion() async throws {
     Subprocess.expect(["/usr/bin/sw_vers", "-productVersion"], standardOutput: "15.0\n".data(using: .utf8))
 
@@ -226,7 +226,7 @@ func testSoftwareVersion() async throws {
 Apply it to a whole suite to cover every test in the type:
 
 ```swift
-@Suite(.subprocessTesting)
+@Suite(.subprocess)
 struct MyCommandTests {
     @Test
     func testGrep() async throws {
@@ -255,7 +255,7 @@ struct MyCommandTests {
 Because each test's mocks are stored in a `@TaskLocal`, parameterised and parallel tests work without any extra setup:
 
 ```swift
-@Test(.subprocessTesting, arguments: ["foo", "bar", "baz"])
+@Test(.subprocess, arguments: ["foo", "bar", "baz"])
 func testEcho(_ word: String) async throws {
     Subprocess.expect(["/bin/echo", word], standardOutput: "\(word)\n".data(using: .utf8))
 
@@ -263,5 +263,21 @@ func testEcho(_ word: String) async throws {
 
     #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == word)
     try Subprocess.verify()
+}
+```
+
+## Unit Testing with XCTest
+
+Since it's not entirely impossible that other tests may need to use `Subprocess` directly any legacy `XCTest`s should now manually setup and tear down the mock dependency builder as shown in the example below.
+
+```swift
+final class SubprocessTests: XCTestCase {
+    override func setUp() {
+        Subprocess.setupMockBuilder()
+    }
+
+    override func tearDown() {
+        Subprocess.reset()
+    }
 }
 ```

--- a/Sources/SubprocessMocks/MockSubprocessDependencyBuilder.swift
+++ b/Sources/SubprocessMocks/MockSubprocessDependencyBuilder.swift
@@ -27,10 +27,10 @@
 
 #if swift(>=6.0)
 public import Foundation
-public import Subprocess
+@testable public import Subprocess
 #else
 import Foundation
-import Subprocess
+@testable import Subprocess
 #endif
 
 /// Error representing a failed call to Subprocess.expect or Shell.expect
@@ -54,7 +54,11 @@ public enum MockSubprocessError: Error, Sendable {
 public protocol SubprocessMockObject {}
 
 public extension SubprocessMockObject {
-
+    /// Setup mocking
+    static func setupMockBuilder() {
+        SubprocessDependencyBuilder.shared = MockSubprocessDependencyBuilder.shared
+    }
+    
     /// Verifies expected stubs and resets mocking
     /// - Throws: A `MockSubprocessError.missedExpectations` containing failed expectations
     static func verify() throws { try MockSubprocessDependencyBuilder.shared.verify() }
@@ -66,7 +70,10 @@ public extension SubprocessMockObject {
     }
 
     /// Resets mocking
-    static func reset() { MockSubprocessDependencyBuilder.shared.reset() }
+    static func reset() {
+        MockSubprocessDependencyBuilder.shared.reset()
+        SubprocessDependencyBuilder.shared = SubprocessDependencyBuilder()
+    }
 }
 
 public class MockFileHandle: FileHandle, @unchecked Sendable {

--- a/Sources/SubprocessTesting/SubprocessTesting.swift
+++ b/Sources/SubprocessTesting/SubprocessTesting.swift
@@ -31,10 +31,17 @@ public struct SubprocessTrait: TestTrait, SuiteTrait, TestScoping {
 }
 
 extension Trait where Self == SubprocessTrait {
+    @available(*, deprecated, renamed: "subprocess")
     public static var subprocessTesting: Self {
         SubprocessTrait()
     }
     
+    /// Creates an isolated mock subprocess dependency builder for the current test task
+    public static var subprocess: Self {
+        SubprocessTrait()
+    }
+    
+    /// Uses the supplied mock subprocess dependency builder for the current test task
     public static func subprocessBuilder(_ builder: MockSubprocessDependencyBuilder) -> Self {
         SubprocessTrait(builder: builder)
     }

--- a/Tests/SystemTests/ShellSystemTests.swift
+++ b/Tests/SystemTests/ShellSystemTests.swift
@@ -3,11 +3,6 @@ import XCTest
 
 @available(*, deprecated, message: "Swift Concurrency methods in Subprocess replace Shell")
 final class ShellSystemTests: XCTestCase {
-
-    override func setUp() {
-        SubprocessDependencyBuilder.shared = SubprocessDependencyBuilder()
-    }
-
     let softwareVersionFilePath = "/System/Library/CoreServices/SystemVersion.plist"
 
     // MARK: Input values

--- a/Tests/SystemTests/SubprocessSystemTests.swift
+++ b/Tests/SystemTests/SubprocessSystemTests.swift
@@ -4,10 +4,6 @@ import XCTest
 final class SubprocessSystemTests: XCTestCase {
     let softwareVersionFilePath = "/System/Library/CoreServices/SystemVersion.plist"
     
-    override func setUp() {
-        SubprocessDependencyBuilder.shared = SubprocessDependencyBuilder()
-    }
-    
     @available(macOS 12.0, *)
     func testRunWithOutput() async throws {
         let result = try await Subprocess(["/bin/cat", softwareVersionFilePath]).run().standardOutput.lines.first(where: { $0.contains("ProductName") }) != nil

--- a/Tests/UnitTests/ShellTests.swift
+++ b/Tests/UnitTests/ShellTests.swift
@@ -16,8 +16,7 @@ final class ShellTests: XCTestCase {
     let command = [ "/usr/local/bin/somefakeCommand", "foo", "bar" ]
 
     override func setUp() {
-        // This is only needed for SwiftPM since it runs all of the test suites as a single test run
-        SubprocessDependencyBuilder.shared = MockSubprocessDependencyBuilder.shared
+        Shell.setupMockBuilder()
     }
 
     override func tearDown() {

--- a/Tests/UnitTests/SubprocessTests.swift
+++ b/Tests/UnitTests/SubprocessTests.swift
@@ -10,8 +10,7 @@ final class SubprocessTests: XCTestCase {
     let command = [ "/usr/local/bin/somefakeCommand", "foo", "bar" ]
     
     override func setUp() {
-        // This is only needed for SwiftPM since it runs all of the test suites as a single test run
-        SubprocessDependencyBuilder.shared = MockSubprocessDependencyBuilder.shared
+        Subprocess.setupMockBuilder()
     }
 
     override func tearDown() {


### PR DESCRIPTION
This pull request introduces improvements to the mocking infrastructure for subprocesses, making it easier and safer to set up and tear down mocks in both Swift Testing and XCTest environments. The main changes include a new static method for setting up mock builders, improved reset behavior, an updated import strategy for internal APIs, and a deprecation/rename of a key test trait. Documentation has also been updated to reflect these changes.

**Mocking Infrastructure Improvements**
- Added a `setupMockBuilder()` static method to `SubprocessMockObject` (and thus to `Shell` and `Subprocess`) to simplify and standardize the setup of mock dependency builders, replacing direct assignment to `SubprocessDependencyBuilder.shared`. (`Sources/SubprocessMocks/MockSubprocessDependencyBuilder.swift`, `CHANGELOG.md`) [[1]](diffhunk://#diff-df89bae161962ed1af21d4568fa83c5caae1ca78eea2fb19c135dc03f9539472R57-R60) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19)
- Modified `SubprocessMockObject.reset()` to also restore `SubprocessDependencyBuilder.shared` to a real instance, so manual teardown in XCTest is no longer required. (`Sources/SubprocessMocks/MockSubprocessDependencyBuilder.swift`, `CHANGELOG.md`) [[1]](diffhunk://#diff-df89bae161962ed1af21d4568fa83c5caae1ca78eea2fb19c135dc03f9539472L69-R76) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19)

**Testing Trait Updates**
- Deprecated the `.subprocessTesting` trait and introduced `.subprocess` as the new name for use with Swift Testing, updating documentation and code accordingly. (`Sources/SubprocessTesting/SubprocessTesting.swift`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-b91c40371f00099fbe67dc078714579258ff6d1cf9c2f5511dc461b5b04fb95cR34-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L207-R215) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R229) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L258-R258) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19)

**Internal API Access for Mocks**
- Changed `SubprocessMocks` to import `Subprocess` with `@testable` to expose internal APIs required for mocking. (`Sources/SubprocessMocks/MockSubprocessDependencyBuilder.swift`, `CHANGELOG.md`) [[1]](diffhunk://#diff-df89bae161962ed1af21d4568fa83c5caae1ca78eea2fb19c135dc03f9539472L30-R33) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19)

**Documentation Updates**
- Updated the `README.md` to reflect the new `.subprocess` trait and added a section on using the new setup/reset methods in XCTest. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L207-R215) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R229) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L258-R258) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R268-R283)

**Test Suite Refactoring**
- Refactored test setup and teardown in unit and system tests to use the new `setupMockBuilder()` and `reset()` methods instead of directly assigning to `SubprocessDependencyBuilder.shared`. (`Tests/UnitTests/ShellTests.swift`, `Tests/UnitTests/SubprocessTests.swift`, `Tests/SystemTests/ShellSystemTests.swift`, `Tests/SystemTests/SubprocessSystemTests.swift`) [[1]](diffhunk://#diff-4d07a56279f468be9667b1d642de187b20e12e859454dbe66bda0d80a5fbdb02L19-R19) [[2]](diffhunk://#diff-a361b7e15efbc8ec6d731b8629cd7a408b96fdc9ebc2dab3f13ebf19b5856abbL13-R13) [[3]](diffhunk://#diff-cf1644329a63058c0e626f4a95db316dbf01274249c69ada824bcba97ed1a7b9L6-L10) [[4]](diffhunk://#diff-b42cdbbcf4e9a75b00ef70d963a088309e892ec3b4d40029f2366f8b2f682c3eL7-L10)