### PR TITLE
Update README.md and swift-testing unit tests for clarity of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,11 @@ func testSoftwareVersion() async throws {
 }
 ```
 
-Apply it to a whole suite to cover every test in the type:
+Apply it to a whole suite to cover every test in the type (all tests inherit the suite level shared `@TaskLock`):
 
 ```swift
-@Suite(.subprocess)
+// Using `.subprocess` at the suite level you will almost certainly need to also use `.serialized`
+@Suite(.serialized, .subprocess)
 struct MyCommandTests {
     @Test
     func testGrep() async throws {

--- a/Tests/SwiftTesting/SubprocessSwiftTests.swift
+++ b/Tests/SwiftTesting/SubprocessSwiftTests.swift
@@ -7,7 +7,7 @@ import SubprocessTesting
 
 @Suite
 struct SubprocessSwiftTests: ~Copyable {
-    @Test(.subprocessTesting, arguments: 0..<100)
+    @Test(.subprocess, arguments: 0..<100)
     func `mocks can handle parallel testing`(_ count: Int) async throws {
         let testFileURL = URL(fileURLWithPath: "/tmp/\(Self.self)-\(UUID().uuidString).txt")
         
@@ -35,7 +35,7 @@ struct SubprocessSwiftTests: ~Copyable {
     }
     
     @Test(arguments: 0..<5)
-    func `other testing still works`(_ count: Int) async throws {
+    func `direct test of command still works`(_ count: Int) async throws {
         let testFileURL: URL = {
             let url = URL(fileURLWithPath: "/tmp/\(Self.self)-\(UUID().uuidString).txt")
             
@@ -49,8 +49,8 @@ struct SubprocessSwiftTests: ~Copyable {
         try FileManager.default.removeItem(at: testFileURL)
     }
     
-    @Test(.subprocessTesting, arguments: ["foo", "bar", "baz"])
-    func testEcho(_ word: String) async throws {
+    @Test(.subprocess, arguments: ["foo", "bar", "baz"])
+    func echo(_ word: String) async throws {
         Subprocess.expect(["/bin/echo", word], standardOutput: "\(word)\n".data(using: .utf8))
 
         let output = try await Subprocess.string(for: ["/bin/echo", word])
@@ -59,8 +59,8 @@ struct SubprocessSwiftTests: ~Copyable {
         try Subprocess.verify()
     }
     
-    @Test(.subprocessTesting)
-    func testSoftwareVersion() async throws {
+    @Test(.subprocess)
+    func `software version`() async throws {
         Subprocess.expect(["/usr/bin/sw_vers", "-productVersion"], standardOutput: "15.0\n".data(using: .utf8))
 
         let version = try await Subprocess.string(for: ["/usr/bin/sw_vers", "-productVersion"])
@@ -70,10 +70,11 @@ struct SubprocessSwiftTests: ~Copyable {
     }
 }
 
-@Suite(.subprocessTesting)
+@Suite(.subprocess)
 struct MyCommandTests: ~Copyable {
-    @Test
-    func testGrep() async throws {
+    // must be serialized otherwise concurrent usage will race against the suite shared mock storage
+    @Test(.serialized, arguments: 0..<10)
+    func grep(count: Int) async throws {
         Subprocess.expect(["/usr/bin/grep", "foo"], standardOutput: "foo bar\n".data(using: .utf8))
 
         let result = try await Subprocess.string(for: ["/usr/bin/grep", "foo"])
@@ -83,13 +84,25 @@ struct MyCommandTests: ~Copyable {
     }
 
     @Test
-    func testMissingFile() async throws {
+    func `missing file`() async throws {
         let error = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT))
         Subprocess.expect(["/bin/cat", "/no/such/file"], error: error)
 
         await #expect(throws: (any Error).self) {
             try await Subprocess.data(for: ["/bin/cat", "/no/such/file"])
         }
+    }
+    
+    // this test creates its own isolated mocks separate from the other tests
+    @Test(.subprocess, arguments: 0..<10)
+    func `grep returns an error`(count: Int) async throws {
+        let error = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT))
+        Subprocess.expect(["/usr/bin/grep", "foo"], error: error)
+
+        await #expect(throws: (any Error).self) {
+            try await Subprocess.string(for: ["/usr/bin/grep", "foo"])
+        }
+        try Subprocess.verify()
     }
 }
 


### PR DESCRIPTION
This pull request updates the subprocess testing infrastructure and test suite organization to improve clarity, consistency, and reliability of parallel and subprocess-related tests. The changes standardize the use of `.subprocess` and `.serialized` annotations, clarify test naming, and introduce new test coverage for error scenarios.

**Test infrastructure and annotation updates:**

- Updated all test and suite annotations to use `.subprocess` instead of the deprecated `.subprocessTesting`, and added `.serialized` where necessary to prevent race conditions with shared mock storage. [[1]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL10-R10) [[2]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL52-R53) [[3]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL62-R63) [[4]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL73-R77) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R230)

**Test naming and organization improvements:**

- Renamed several test functions for clarity and consistency, such as changing `testEcho` to `echo`, `testSoftwareVersion` to ``software version``, and `testMissingFile` to ``missing file``. [[1]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL38-R38) [[2]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL52-R53) [[3]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL62-R63) [[4]](diffhunk://#diff-b6c16ea440502f087a4a6ac850e1bd6f0f513479fd4127a356be7d3c9dfc3c8dL86-R106)

**New and enhanced test coverage:**

- Added a new test ``grep returns an error`` to specifically verify error handling when `grep` fails, using isolated mocks for this scenario.

**Documentation improvements:**

- Updated documentation in `README.md` to clarify the need for `.serialized` when using `.subprocess` at the suite level, to ensure proper test isolation.

These changes help ensure that subprocess tests are more robust, easier to understand, and less prone to issues with concurrent execution.